### PR TITLE
updated docker compose to work with new mac arch

### DIFF
--- a/.github/workflows/check_docker_build.yml
+++ b/.github/workflows/check_docker_build.yml
@@ -6,7 +6,8 @@ on:
     paths:
       - "docker/Dockerfile.web.dev"
       - "docker/requirements.web.dev"
-
+      - "docker/docker-compose.dev.yml"
+      - "docker/docker-compose.yml"
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/docker/docker-compose.dev.prod.yml
+++ b/docker/docker-compose.dev.prod.yml
@@ -27,10 +27,9 @@ services:
           DB_CONFIG: /opt/project/db_configuration
         env_file:
           - ".env"
-        platform: linux/amd64
     yse_db:
       container_name: ysepz_db_container
-      image: "mysql:8.0.30-oracle"
+      image: "mysql:8.0.25"
       command: mysqld --default-authentication-plugin=mysql_native_password
       ports:
         - "${LOCAL_DB_PORT}:3306"
@@ -55,8 +54,3 @@ services:
         - ${STATIC_VOL}:/static
       depends_on:
         - web
-
-
-
-
-

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -27,6 +27,7 @@ services:
           DB_CONFIG: /opt/project/db_configuration
         env_file:
           - ".env"
+        platform: linux/amd64
     yse_db:
       container_name: ysepz_db_container
       image: "mysql:8.0.25"

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -2,10 +2,7 @@ version: '2'
 services:
     web:
         container_name: ysepz_web_container
-        build:
-          context: ""
-          dockerfile: Dockerfile.web.dev
-        image: "local/yse_pz_web:dev"
+        image: "ghcr.io/davecoulter/yse_pz:latest"
         volumes:
             - ${VOL}:/app
             - ./entrypoints:/app/Entrypoints
@@ -27,10 +24,9 @@ services:
           DB_CONFIG: /opt/project/db_configuration
         env_file:
           - ".env"
-        platform: linux/amd64
     yse_db:
       container_name: ysepz_db_container
-      image: "mysql:8.0.30-oracle"
+      image: "mysql:8.0.25"
       command: mysqld --default-authentication-plugin=mysql_native_password
       ports:
         - "${LOCAL_DB_PORT}:3306"
@@ -55,8 +51,3 @@ services:
         - ${STATIC_VOL}:/static
       depends_on:
         - web
-
-
-
-
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         platform: linux/amd64
     yse_db:
       container_name: ysepz_db_container
-      image: "mysql:8.0.25"
+      image: "mysql:8.0.30-oracle"
       command: mysqld --default-authentication-plugin=mysql_native_password
       ports:
         - "${LOCAL_DB_PORT}:3306"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,7 @@ services:
           DB_CONFIG: /opt/project/db_configuration
         env_file:
           - ".env"
+        platform: linux/amd64
     yse_db:
       container_name: ysepz_db_container
       image: "mysql:8.0.25"


### PR DESCRIPTION
Fixes #  <!-- If your PR relates to an issue mention it here e.g. Issue #34, Issue #56 -->.

## Description of the Change

The docker compose up does not work on the new Mac M1 chips. Adding the platform command to the docker compose files should fix this, and changing mysql version should change this. 

I also changed the docker check workflow to spin up if docker compose files are changed. 

Both docker compose up for normal and dev works for me with this platform addition to the docker compose files, and I do not have an M1 chip.

I've renamed the old docker compose files to have .prod suffix so production can still be replicated.

## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [ ] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change
- [x] Meta change

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->

This is a meta change changing how we spin up and build images, this branch should be checked out locally and docker compose up should be be run for both dev and normal compose files - I don't think the auto build PR check will actually see this change. 
