### PR TITLE
Add SNAD ZTF DR cone search button

### DIFF
--- a/YSE_App/templates/YSE_App/transient_detail.html
+++ b/YSE_App/templates/YSE_App/transient_detail.html
@@ -541,6 +541,11 @@
                                                     <a class="btn btn-block btn-primary" href="https://mars.lco.global/?sort_value=jd&sort_order=desc&cone={{transient.ra}}%2C{{transient.dec}}%2C0.0014" target="_blank">ZTF Cone Search</a>
                                                 </div>
                                             </div>
+                                            <div class="col-xs-6">
+                                                <div class="form-group">
+                                                    <a class="btn btn-block btn-primary" href="https://ztf.snad.space/search/{{transient.ra}}%20{{transient.dec}}/5" target="_blank">SNAD ZTF DR</a>
+                                                </div>
+                                            </div>
                                             {% if transient.postage_stamp_file %}
                                             <div class="col-xs-6">
                                                 <div class="form-group">


### PR DESCRIPTION
## Description of the Change

Add "ZTF SNAD DR" button to "external links" section of the transient detail page.
## Checklist

Please check all that apply to your proposed changes

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] HTML code change
- [ ] Added package dependency
- [ ] Added data
- [ ] Changed django model
- [ ] Documentation change

### **Additional context**
<!-- Add any other context or additional information about the problem here.-->

SNAD ZTF viewer is useful to check ZTF Data Release photometry as well as Gaia DR3 and Pan-Starrs DR 2 light curves