### PR TITLE
Add platforms keyword for compatibility with Mac silicon chips

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     web:
         container_name: ysepz_web_container
         image: "ghcr.io/davecoulter/yse_pz:latest"
+        platform: linux/amd64
         volumes:
             - ${VOL}:/app
             - ./entrypoints:/app/Entrypoints
@@ -30,6 +31,7 @@ services:
     yse_db:
       container_name: ysepz_db_container
       image: "mysql:8.0.25"
+      platform: linux/amd64
       command: mysqld --default-authentication-plugin=mysql_native_password
       ports:
         - "${LOCAL_DB_PORT}:3306"


### PR DESCRIPTION
Adds a `platforms` keyword to enable compatibility with the Mac M1+ chips.  